### PR TITLE
Support Linux environment variables

### DIFF
--- a/authentication-lib-main/src/main/java/com/sphereon/libs/authentication/impl/config/backends/SystemEnvPropertyBackend.java
+++ b/authentication-lib-main/src/main/java/com/sphereon/libs/authentication/impl/config/backends/SystemEnvPropertyBackend.java
@@ -39,7 +39,7 @@ public class SystemEnvPropertyBackend extends InMemoryConfig {
         }
         if (StringUtils.isEmpty(value)) {
             // The export command on Unix OS types do not support dot's in env vars. Try read when replacing with _
-            value = System.getenv(propertyVarName.replace(".", "_"));
+            value = System.getenv(propertyVarName.replace('.', '_').replace('-', '_'));
         }
         if (StringUtils.isEmpty(value)) {
             value = System.getProperty(propertyPrefix + key.getValue());


### PR DESCRIPTION
These environment variables will have dashes and dots in them. This fix replaces them both with underscores